### PR TITLE
fix: Limit of camera is not based on map width

### DIFF
--- a/Castlevania/Game.h
+++ b/Castlevania/Game.h
@@ -57,6 +57,7 @@ public:
 
 	void Load(LPCWSTR gameFile);
 	LPSCENE GetCurrentScene() { return scenes[current_scene]; }
+	int GetCurrentSceneID() { return current_scene; }
 	void SwitchScene(int scene_id);
 
 	int GetScreenWidth() { return screen_width; }

--- a/Castlevania/PlayScence.cpp
+++ b/Castlevania/PlayScence.cpp
@@ -315,7 +315,9 @@ void CPlayScene::Update(DWORD dt)
 	cy -= game->GetScreenHeight() / 2;
 	//CGame::GetInstance()->SetCamPos(cx, 0.0f /*cy*/);
 	// check if current player pos is in map range and update cam pos accordingly
-	if (cx > 0 && cx < 730)
+	int currentMapID = CGame::GetInstance()->GetCurrentSceneID();
+	int mapWidth = CMaps::GetInstance()->Get(currentMapID)->getMapWidth();
+	if (cx > 0 && cx < (mapWidth / 2 - TILE_SIZE) ) //to make sure it won't be out of range
 	{
 		Camera::GetInstance()->SetCamPos(cx, 0.0f /*cy*/);
 	}

--- a/Castlevania/PlayScence.h
+++ b/Castlevania/PlayScence.h
@@ -10,6 +10,7 @@
 #include "GameMap.h"
 #include "FirePot.h"
 #include "Item.h"
+#include "GameMap.h"
 
 class CPlayScene: public CScene
 {


### PR DESCRIPTION
Remove hardcoding number when render map following camera